### PR TITLE
Season_folders was inverted

### DIFF
--- a/sickbeard/webapi.py
+++ b/sickbeard/webapi.py
@@ -1960,7 +1960,7 @@ class CMDShowAddExisting(ApiCall):
         self.initial, args = self.check_params(args, kwargs, "initial", [], False, "list", ALLOWED_QUALITY_LIST)
         self.archive, args = self.check_params(args, kwargs, "archive", [], False, "list", PREFERRED_QUALITY_LIST)
         self.season_folders, args = self.check_params(args, kwargs, "flatten_folders",
-                                                      not bool(sickbeard.SEASON_FOLDERS_DEFAULT), False, "bool", [])
+                                                      bool(sickbeard.SEASON_FOLDERS_DEFAULT), False, "bool", [])
         self.season_folders, args = self.check_params(args, kwargs, "season_folders",
                                                       self.season_folders, False, "bool", [])
         self.subtitles, args = self.check_params(args, kwargs, "subtitles", int(sickbeard.USE_SUBTITLES),
@@ -2049,7 +2049,7 @@ class CMDShowAddNew(ApiCall):
         self.archive, args = self.check_params(
             args, kwargs, "archive", None, False, "list", PREFERRED_QUALITY_LIST)
         self.season_folders, args = self.check_params(args, kwargs, "flatten_folders",
-                                                      not bool(sickbeard.SEASON_FOLDERS_DEFAULT), False, "bool", [])
+                                                      bool(sickbeard.SEASON_FOLDERS_DEFAULT), False, "bool", [])
         self.season_folders, args = self.check_params(args, kwargs, "season_folders",
                                                       self.season_folders, False, "bool", [])
         self.status, args = self.check_params(args, kwargs, "status", None, False, "string",


### PR DESCRIPTION
The value was incorrectly inverted, causing the default via the api to be incorrect.

Fixes #3978

Proposed changes in this pull request:
-
-
-

- [X] PR is based on the DEVELOP branch
- [X] Read [contribution guide](https://github.com/SickRage/SickRage/blob/master/.github/CONTRIBUTING.md)
